### PR TITLE
Switch from HTTP to HTTPS and rewrite an SSH link to an HTTPS link

### DIFF
--- a/src/ru/trylogic/idea/gitlab/integration/utils/GitlabUrlUtil.java
+++ b/src/ru/trylogic/idea/gitlab/integration/utils/GitlabUrlUtil.java
@@ -25,13 +25,17 @@ public class GitlabUrlUtil {
 
     public static String makeRepoUrlFromRemoteUrl(@NotNull String remoteUrl) {
         String cleanedFromDotGit = StringUtil.trimEnd(remoteUrl, ".git");
-        
+
         if (remoteUrl.startsWith("http://") || remoteUrl.startsWith("https://")) {
             return cleanedFromDotGit;
         } else if (remoteUrl.startsWith("git@")) {
             String cleanedFromGitAt = StringUtil.trimStart(cleanedFromDotGit, "git@");
 
-            return "http://" + StringUtil.replace(cleanedFromGitAt, ":", "/");
+            return "https://" + StringUtil.replace(cleanedFromGitAt, ":", "/");
+        } else if (remoteUrl.startsWith("ssh://git@")) {
+            String cleanedFromSshGitAt = StringUtil.trimStart(cleanedFromDotGit,"ssh://git@");
+
+            return "https://" + cleanedFromSshGitAt.replaceFirst(":\\d+(?=/)","");
         } else {
             throw new IllegalStateException("Invalid remote Gitlab url: " + remoteUrl);
         }


### PR DESCRIPTION
The standard ssh link that gitlab uses can be rewritten to the equivalent http(s) version by removing the port number and replace ssh://git@ with http(s)://. This should fix most problems for ssh users #17.

I also switched from http to https, since usually you shouldn't connect with plain http anyway and sometimes plain http isn't even supported.
